### PR TITLE
synchronously recompute value after state change

### DIFF
--- a/packages/core/src/state/state.observer.ts
+++ b/packages/core/src/state/state.observer.ts
@@ -19,6 +19,7 @@ import {
 } from './state.runtime.job';
 import { SideEffectInterface, State } from './state';
 import { logCodeManager } from '../logCodeManager';
+import { Computed } from '../computed';
 
 export class StateObserver<ValueType = any> extends Observer<ValueType> {
   // State the Observer belongs to
@@ -65,9 +66,8 @@ export class StateObserver<ValueType = any> extends Observer<ValueType> {
     const state = this.state() as any;
 
     if (state.isComputed) {
-      state.compute().then((result) => {
-        this.ingestValue(result, config);
-      });
+      const computedState = state as Computed;
+      computedState.computeAndIngest(this, config);
     } else {
       this.ingestValue(state.nextStateValue, config);
     }

--- a/packages/core/tests/unit/state/state.observer.test.ts
+++ b/packages/core/tests/unit/state/state.observer.test.ts
@@ -143,13 +143,13 @@ describe('StateObserver Tests', () => {
         "should call 'ingestValue' with computed value " +
           'if Observer belongs to a Computed State (default config)',
         async () => {
-          dummyComputed.compute = jest.fn(() =>
-            Promise.resolve('computedValue')
+          (dummyComputed as any).computeSync = jest.fn(() =>
+            'computedValue'
           );
 
           computedObserver.ingest();
 
-          expect(dummyComputed.compute).toHaveBeenCalled();
+          expect((dummyComputed as any).computeSync).toHaveBeenCalled();
           await waitForExpect(() => {
             expect(computedObserver.ingestValue).toHaveBeenCalledWith(
               'computedValue',


### PR DESCRIPTION
These changes will allow synchronous updates to computed states. To accomplish this I made the following changes:
- cache if the function is asynchronous
- before computing the value, check if it needs to be computed asynchronously. If not do it synchronously.
- added a test, to test these changes
- fixed some tests, since some methods have changed in usage and naming

## 📄 Description
Bug fix, see #219 

## 🔴 Related Issue
Related issue #219 

## 📃 Context
Seems to be a bug/missing feature so far.

## 🛠 How Has This Been Tested?
Added a new test to "computed.test.ts" to verify that the changes work.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include information about your testing environment, and the tests you ran to -->
<!--- see how your change might have affects other areas of the code, etc. -->
